### PR TITLE
Add sample course pages, fake-data API, and home page

### DIFF
--- a/src/app/courses/[id]/page.tsx
+++ b/src/app/courses/[id]/page.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link';
+import { getCourse } from '@/lib/courses';
+
+export default async function CoursePage({ params }: { params: { id: string } }) {
+  const course = await getCourse(params.id);
+  return (
+    <main style={{ padding: '1rem' }}>
+      <h1>{course.title}</h1>
+      <p>{course.description}</p>
+      <Link href="/courses">Back to courses</Link>
+    </main>
+  );
+}

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+import { getCourses } from '@/lib/courses';
+
+export default async function CoursesPage() {
+  const courses = await getCourses();
+  return (
+    <main style={{ padding: '1rem' }}>
+      <h1>Courses</h1>
+      <ul>
+        {courses.map((course) => (
+          <li key={course.id}>
+            <Link href={`/courses/${course.id}`}>{course.title}</Link>
+            <p>{course.description}</p>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,26 @@
-export default function Home() {
-	return <h1 className="text-3xl font-bold underline">Hello world!</h1>;
+import Link from 'next/link';
+import { getCourses } from '@/lib/courses';
+
+export default async function Home() {
+  const courses = await getCourses();
+  return (
+    <main style={{ padding: '1rem' }}>
+      <section style={{ marginBottom: '2rem' }}>
+        <h1>Welcome to the Academy</h1>
+        <p>Interactive courses to sharpen your skills.</p>
+        <Link href="/courses">Browse all courses</Link>
+      </section>
+      <section>
+        <h2>Featured Courses</h2>
+        <ul>
+          {courses.map((course) => (
+            <li key={course.id}>
+              <Link href={`/courses/${course.id}`}>{course.title}</Link>
+              <p>{course.description}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
 }

--- a/src/data/courses.ts
+++ b/src/data/courses.ts
@@ -1,0 +1,23 @@
+export type Course = {
+  id: string;
+  title: string;
+  description: string;
+};
+
+export const courses: Course[] = [
+  {
+    id: 'intro-math',
+    title: 'Intro to Mathematics',
+    description: 'Learn basic math operations with interactive problems.',
+  },
+  {
+    id: 'physics-basics',
+    title: 'Physics Basics',
+    description: 'Explore fundamental physics concepts like motion and energy.',
+  },
+  {
+    id: 'cs-fundamentals',
+    title: 'Computer Science Fundamentals',
+    description: 'Understand algorithms and data structures through puzzles.',
+  },
+];

--- a/src/lib/courses.ts
+++ b/src/lib/courses.ts
@@ -1,0 +1,20 @@
+import type { Course } from '@/data/courses';
+
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000';
+
+export async function getCourses(): Promise<Course[]> {
+  const res = await fetch(`${baseUrl}/api/courses`, { cache: 'no-store' });
+  if (!res.ok) {
+    throw new Error('Failed to fetch courses');
+  }
+  return res.json();
+}
+
+export async function getCourse(id: string): Promise<Course> {
+  const res = await fetch(`${baseUrl}/api/courses/${id}`, { cache: 'no-store' });
+  if (!res.ok) {
+    throw new Error('Failed to fetch course');
+  }
+  return res.json();
+}
+

--- a/src/pages/api/courses/[id].ts
+++ b/src/pages/api/courses/[id].ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { courses } from '@/data/courses';
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const { id } = req.query;
+  const course = courses.find((c) => c.id === id);
+  if (course) {
+    res.status(200).json(course);
+  } else {
+    res.status(404).json({ message: 'Course not found' });
+  }
+}

--- a/src/pages/api/courses/index.ts
+++ b/src/pages/api/courses/index.ts
@@ -1,0 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { courses } from '@/data/courses';
+
+export default function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  res.status(200).json(courses);
+}


### PR DESCRIPTION
## Summary
- add fake course data and API endpoints
- add course list and detail pages using the API
- build home page with featured course preview
- centralize course fetching in shared helper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688eac9a0b388326be441a9b26040f7b