### PR TITLE
Add contractor training pages and dashboard

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,19 @@
+import { Box, Heading, Text } from '@chakra-ui/react';
+
+export default function AboutPage() {
+  return (
+    <Box p={8} maxW="3xl" mx="auto">
+      <Heading mb={4}>About Contractor Academy</Heading>
+      <Text mb={2}>
+        Contractor Academy provides interactive continuing education for
+        tradespeople. Our mission is to make it simple for contractors to stay
+        licensed and sharp through hands-on courses and up-to-date code
+        reviews.
+      </Text>
+      <Text>
+        Lessons are authored by industry experts and are broken down into
+        digestible modules you can tackle at your own pace.
+      </Text>
+    </Box>
+  );
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,19 @@
+import { Box, Heading, Text, Link } from '@chakra-ui/react';
+
+export default function ContactPage() {
+  return (
+    <Box p={8} maxW="3xl" mx="auto">
+      <Heading mb={4}>Contact Us</Heading>
+      <Text mb={2}>
+        Have questions about courses or enterprise plans? Reach out and we will
+        get back to you shortly.
+      </Text>
+      <Text>
+        Email us at{' '}
+        <Link href="mailto:support@contractoracademy.test" color="blue.500">
+          support@contractoracademy.test
+        </Link>
+      </Text>
+    </Box>
+  );
+}

--- a/src/app/courses/[id]/page.tsx
+++ b/src/app/courses/[id]/page.tsx
@@ -1,4 +1,5 @@
-import Link from 'next/link';
+import NextLink from 'next/link';
+import { Box, Heading, Text, Link as ChakraLink } from '@chakra-ui/react';
 
 export type Course = {
   id: string;
@@ -15,13 +16,19 @@ async function getCourse(id: string): Promise<Course> {
   return res.json();
 }
 
-export default async function CoursePage({ params }: { params: { id: string } }) {
+export default async function CoursePage({
+  params,
+}: {
+  params: { id: string };
+}) {
   const course = await getCourse(params.id);
   return (
-    <main style={{ padding: '1rem' }}>
-      <h1>{course.title}</h1>
-      <p>{course.description}</p>
-      <Link href="/courses">Back to courses</Link>
-    </main>
+    <Box p={8} maxW="3xl" mx="auto">
+      <Heading mb={4}>{course.title}</Heading>
+      <Text mb={6}>{course.description}</Text>
+      <ChakraLink as={NextLink} href="/courses" color="blue.500">
+        Back to courses
+      </ChakraLink>
+    </Box>
   );
 }

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -1,4 +1,11 @@
-import Link from 'next/link';
+import NextLink from 'next/link';
+import {
+  Box,
+  Heading,
+  Text,
+  VStack,
+  Link as ChakraLink,
+} from '@chakra-ui/react';
 
 export type Course = {
   id: string;
@@ -18,16 +25,22 @@ async function getCourses(): Promise<Course[]> {
 export default async function CoursesPage() {
   const courses = await getCourses();
   return (
-    <main style={{ padding: '1rem' }}>
-      <h1>Courses</h1>
-      <ul>
+    <Box p={8} maxW="4xl" mx="auto">
+      <Heading mb={6}>Courses</Heading>
+      <VStack spacing={6} align="stretch">
         {courses.map((course) => (
-          <li key={course.id}>
-            <Link href={`/courses/${course.id}`}>{course.title}</Link>
-            <p>{course.description}</p>
-          </li>
+          <Box key={course.id} p={4} borderWidth="1px" rounded="md">
+            <ChakraLink
+              as={NextLink}
+              href={`/courses/${course.id}`}
+              fontWeight="bold"
+            >
+              {course.title}
+            </ChakraLink>
+            <Text>{course.description}</Text>
+          </Box>
         ))}
-      </ul>
-    </main>
+      </VStack>
+    </Box>
   );
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,26 @@
+import { Box, Heading, Progress, Text, VStack } from '@chakra-ui/react';
+import { courses } from '@/data/courses';
+
+const userProgress: Record<string, number> = {
+  'osha-safety': 40,
+  'electrical-code': 20,
+  'plumbing-basics': 0,
+};
+
+export default function DashboardPage() {
+  return (
+    <Box p={8} maxW="4xl" mx="auto">
+      <Heading mb={6}>My Dashboard</Heading>
+      <VStack spacing={6} align="stretch">
+        {courses.map((course) => (
+          <Box key={course.id}>
+            <Text fontWeight="bold" mb={2}>
+              {course.title}
+            </Text>
+            <Progress value={userProgress[course.id] ?? 0} />
+          </Box>
+        ))}
+      </VStack>
+    </Box>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,14 @@
 "use client";
 import "./globals.css";
-import { ChakraProvider } from "@chakra-ui/react";
+import NextLink from "next/link";
+import {
+  ChakraProvider,
+  Box,
+  Flex,
+  Heading,
+  HStack,
+  Link as ChakraLink,
+} from "@chakra-ui/react";
 import { RecoilRoot } from "recoil";
 
 export default function RootLayout({
@@ -11,11 +19,42 @@ export default function RootLayout({
 	return (
 		<html lang="en">
 			<head />
-			<body>
-				<RecoilRoot>
-					<ChakraProvider>{children}</ChakraProvider>
-				</RecoilRoot>
-			</body>
-		</html>
-	);
+                        <body>
+                                <RecoilRoot>
+                                        <ChakraProvider>
+                                                <Box as="header" bg="gray.100" px={4} py={3} mb={6}>
+                                                        <Flex
+                                                                align="center"
+                                                                justify="space-between"
+                                                                maxW="6xl"
+                                                                mx="auto"
+                                                        >
+                                                                <Heading size="md">
+                                                                        Contractor Academy
+                                                                </Heading>
+                                                                <HStack spacing={4}>
+                                                                        <ChakraLink as={NextLink} href="/">
+                                                                                Home
+                                                                        </ChakraLink>
+                                                                        <ChakraLink as={NextLink} href="/courses">
+                                                                                Courses
+                                                                        </ChakraLink>
+                                                                        <ChakraLink as={NextLink} href="/dashboard">
+                                                                                Dashboard
+                                                                        </ChakraLink>
+                                                                        <ChakraLink as={NextLink} href="/about">
+                                                                                About
+                                                                        </ChakraLink>
+                                                                        <ChakraLink as={NextLink} href="/contact">
+                                                                                Contact
+                                                                        </ChakraLink>
+                                                                </HStack>
+                                                        </Flex>
+                                                </Box>
+                                                {children}
+                                        </ChakraProvider>
+                                </RecoilRoot>
+                        </body>
+                </html>
+        );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,20 @@
-import Link from 'next/link';
+import NextLink from 'next/link';
+import { Box, Button, Heading, Text, Stack } from '@chakra-ui/react';
 
 export default function Home() {
   return (
-    <main style={{ padding: '1rem' }}>
-      <h1>Welcome to the Academy</h1>
-      <Link href="/courses">Browse Courses</Link>
-    </main>
+    <Box p={8} textAlign="center">
+      <Stack spacing={4} align="center">
+        <Heading>Contractor Training Academy</Heading>
+        <Text maxW="2xl">
+          Upgrade your skills with interactive courses designed for licensed
+          contractors. Earn continuing education credits and stay up to date
+          with the latest codes and safety practices.
+        </Text>
+        <Button as={NextLink} href="/courses" colorScheme="blue">
+          Browse Courses
+        </Button>
+      </Stack>
+    </Box>
   );
 }

--- a/src/data/courses.ts
+++ b/src/data/courses.ts
@@ -6,18 +6,20 @@ export type Course = {
 
 export const courses: Course[] = [
   {
-    id: 'intro-math',
-    title: 'Intro to Mathematics',
-    description: 'Learn basic math operations with interactive problems.',
+    id: 'osha-safety',
+    title: 'OSHA Safety Training',
+    description: 'Comply with OSHA regulations and keep your job sites safe.',
   },
   {
-    id: 'physics-basics',
-    title: 'Physics Basics',
-    description: 'Explore fundamental physics concepts like motion and energy.',
+    id: 'electrical-code',
+    title: 'Electrical Code Update',
+    description:
+      'Understand the latest National Electrical Code requirements for contractors.',
   },
   {
-    id: 'cs-fundamentals',
-    title: 'Computer Science Fundamentals',
-    description: 'Understand algorithms and data structures through puzzles.',
+    id: 'plumbing-basics',
+    title: 'Residential Plumbing Basics',
+    description:
+      'Review common plumbing systems and installation best practices.',
   },
 ];


### PR DESCRIPTION
## Summary
- Replace sample courses with contractor training topics
- Build home, about, contact, and dashboard pages with Chakra UI
- Add site-wide navigation and style courses pages

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6890d72f1278832688a4ab98579e7c75