### PR TITLE
Add dark theme and state-specific interactive courses

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,19 @@
+import { Box, Heading, Text } from '@chakra-ui/react';
+
+export default function AboutPage() {
+  return (
+    <Box p={8} maxW="3xl" mx="auto">
+      <Heading mb={4}>About Contractor Academy</Heading>
+      <Text mb={2}>
+        Contractor Academy provides interactive continuing education for
+        tradespeople. Our mission is to make it simple for contractors to stay
+        licensed and sharp through hands-on courses and up-to-date code
+        reviews.
+      </Text>
+      <Text>
+        Lessons are authored by industry experts and are broken down into
+        digestible modules you can tackle at your own pace.
+      </Text>
+    </Box>
+  );
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,19 @@
+import { Box, Heading, Text, Link } from '@chakra-ui/react';
+
+export default function ContactPage() {
+  return (
+    <Box p={8} maxW="3xl" mx="auto">
+      <Heading mb={4}>Contact Us</Heading>
+      <Text mb={2}>
+        Have questions about courses or enterprise plans? Reach out and we will
+        get back to you shortly.
+      </Text>
+      <Text>
+        Email us at{' '}
+        <Link href="mailto:support@contractoracademy.test" color="blue.500">
+          support@contractoracademy.test
+        </Link>
+      </Text>
+    </Box>
+  );
+}

--- a/src/app/courses/[id]/page.tsx
+++ b/src/app/courses/[id]/page.tsx
@@ -1,10 +1,6 @@
-import Link from 'next/link';
-
-export type Course = {
-  id: string;
-  title: string;
-  description: string;
-};
+import { Box } from '@chakra-ui/react';
+import CourseContent from '@/components/CourseContent';
+import type { Course } from '@/data/courses';
 
 async function getCourse(id: string): Promise<Course> {
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000';
@@ -15,13 +11,15 @@ async function getCourse(id: string): Promise<Course> {
   return res.json();
 }
 
-export default async function CoursePage({ params }: { params: { id: string } }) {
+export default async function CoursePage({
+  params,
+}: {
+  params: { id: string };
+}) {
   const course = await getCourse(params.id);
   return (
-    <main style={{ padding: '1rem' }}>
-      <h1>{course.title}</h1>
-      <p>{course.description}</p>
-      <Link href="/courses">Back to courses</Link>
-    </main>
+    <Box p={8} maxW="3xl" mx="auto">
+      <CourseContent course={course} />
+    </Box>
   );
 }

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -1,10 +1,12 @@
-import Link from 'next/link';
-
-export type Course = {
-  id: string;
-  title: string;
-  description: string;
-};
+import NextLink from 'next/link';
+import {
+  Box,
+  Heading,
+  Text,
+  VStack,
+  Link as ChakraLink,
+} from '@chakra-ui/react';
+import type { Course } from '@/data/courses';
 
 async function getCourses(): Promise<Course[]> {
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000';
@@ -18,16 +20,26 @@ async function getCourses(): Promise<Course[]> {
 export default async function CoursesPage() {
   const courses = await getCourses();
   return (
-    <main style={{ padding: '1rem' }}>
-      <h1>Courses</h1>
-      <ul>
+    <Box p={8} maxW="4xl" mx="auto">
+      <Heading mb={6}>Courses</Heading>
+      <VStack spacing={6} align="stretch">
         {courses.map((course) => (
-          <li key={course.id}>
-            <Link href={`/courses/${course.id}`}>{course.title}</Link>
-            <p>{course.description}</p>
-          </li>
+          <Box key={course.id} p={4} borderWidth="1px" rounded="md" bg="gray.900">
+            <ChakraLink
+              as={NextLink}
+              href={`/courses/${course.id}`}
+              fontWeight="bold"
+              color="teal.300"
+            >
+              {course.title}
+            </ChakraLink>
+            <Text>{course.description}</Text>
+            <Text fontSize="sm" color="gray.400">
+              Trade: {course.trade}
+            </Text>
+          </Box>
         ))}
-      </ul>
-    </main>
+      </VStack>
+    </Box>
   );
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,26 @@
+import { Box, Heading, Progress, Text, VStack } from '@chakra-ui/react';
+import { courses } from '@/data/courses';
+
+const userProgress: Record<string, number> = {
+  'plumbing-prv': 40,
+  'hvac-maintenance': 20,
+  'electrical-panel': 0,
+};
+
+export default function DashboardPage() {
+  return (
+    <Box p={8} maxW="4xl" mx="auto">
+      <Heading mb={6}>My Dashboard</Heading>
+      <VStack spacing={6} align="stretch">
+        {courses.map((course) => (
+          <Box key={course.id} p={4} borderWidth="1px" rounded="md" bg="gray.900">
+            <Text fontWeight="bold" mb={2}>
+              {course.title}
+            </Text>
+            <Progress value={userProgress[course.id] ?? 0} />
+          </Box>
+        ))}
+      </VStack>
+    </Box>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,16 @@
 "use client";
 import "./globals.css";
-import { ChakraProvider } from "@chakra-ui/react";
+import NextLink from "next/link";
+import {
+  ChakraProvider,
+  Box,
+  Flex,
+  Heading,
+  HStack,
+  Link as ChakraLink,
+} from "@chakra-ui/react";
 import { RecoilRoot } from "recoil";
+import theme from "@/theme";
 
 export default function RootLayout({
 	children,
@@ -11,11 +20,69 @@ export default function RootLayout({
 	return (
 		<html lang="en">
 			<head />
-			<body>
-				<RecoilRoot>
-					<ChakraProvider>{children}</ChakraProvider>
-				</RecoilRoot>
-			</body>
-		</html>
-	);
+                        <body>
+                                <RecoilRoot>
+                                <ChakraProvider theme={theme}>
+                                                <Box
+                                                        as="header"
+                                                        bg="black"
+                                                        borderBottom="1px solid"
+                                                        borderColor="gray.800"
+                                                        px={6}
+                                                        py={4}
+                                                >
+                                                        <Flex
+                                                                align="center"
+                                                                justify="space-between"
+                                                                maxW="6xl"
+                                                                mx="auto"
+                                                        >
+                                                                <Heading size="md" color="white">
+                                                                        Contractor Academy
+                                                                </Heading>
+                                                                <HStack spacing={6} color="white">
+                                                                        <ChakraLink
+                                                                                as={NextLink}
+                                                                                href="/"
+                                                                                _hover={{ color: "gray.400" }}
+                                                                        >
+                                                                                Home
+                                                                        </ChakraLink>
+                                                                        <ChakraLink
+                                                                                as={NextLink}
+                                                                                href="/courses"
+                                                                                _hover={{ color: "gray.400" }}
+                                                                        >
+                                                                                Courses
+                                                                        </ChakraLink>
+                                                                        <ChakraLink
+                                                                                as={NextLink}
+                                                                                href="/dashboard"
+                                                                                _hover={{ color: "gray.400" }}
+                                                                        >
+                                                                                Dashboard
+                                                                        </ChakraLink>
+                                                                        <ChakraLink
+                                                                                as={NextLink}
+                                                                                href="/about"
+                                                                                _hover={{ color: "gray.400" }}
+                                                                        >
+                                                                                About
+                                                                        </ChakraLink>
+                                                                        <ChakraLink
+                                                                                as={NextLink}
+                                                                                href="/contact"
+                                                                                _hover={{ color: "gray.400" }}
+                                                                        >
+                                                                                Contact
+                                                                        </ChakraLink>
+                                                                </HStack>
+                                                        </Flex>
+                                                </Box>
+                                                {children}
+                                        </ChakraProvider>
+                                </RecoilRoot>
+                        </body>
+                </html>
+        );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,19 @@
-import Link from 'next/link';
+import NextLink from 'next/link';
+import { Box, Button, Heading, Text, Stack } from '@chakra-ui/react';
 
 export default function Home() {
   return (
-    <main style={{ padding: '1rem' }}>
-      <h1>Welcome to the Academy</h1>
-      <Link href="/courses">Browse Courses</Link>
-    </main>
+    <Box py={24} textAlign="center">
+      <Stack spacing={6} align="center">
+        <Heading size="2xl">Contractor Training Academy</Heading>
+        <Text maxW="2xl">
+          Interactive learning for plumbing, HVAC, and electrical professionals
+          with state‑specific code references.
+        </Text>
+        <Button as={NextLink} href="/courses" colorScheme="teal">
+          Browse Courses
+        </Button>
+      </Stack>
+    </Box>
   );
 }

--- a/src/components/CourseContent.tsx
+++ b/src/components/CourseContent.tsx
@@ -1,0 +1,44 @@
+"use client";
+import { useState } from 'react';
+import NextLink from 'next/link';
+import {
+  Box,
+  Heading,
+  Text,
+  Select,
+  Link as ChakraLink,
+} from '@chakra-ui/react';
+import type { Course } from '@/data/courses';
+
+export default function CourseContent({ course }: { course: Course }) {
+  const [state, setState] = useState('');
+  const info = state ? course.states[state] : undefined;
+
+  return (
+    <Box>
+      <Heading mb={4}>{course.title}</Heading>
+      <Text mb={6}>{course.description}</Text>
+      <Select
+        placeholder="Select your state"
+        mb={4}
+        value={state}
+        onChange={(e) => setState(e.target.value)}
+      >
+        {Object.keys(course.states).map((abbr) => (
+          <option key={abbr} value={abbr}>
+            {abbr}
+          </option>
+        ))}
+      </Select>
+      {info && (
+        <Box p={4} borderWidth="1px" rounded="md" bg="gray.900" mb={4}>
+          <Text fontWeight="bold">{info.codeSection}</Text>
+          <Text>{info.guidance}</Text>
+        </Box>
+      )}
+      <ChakraLink as={NextLink} href="/courses" color="teal.300">
+        Back to courses
+      </ChakraLink>
+    </Box>
+  );
+}

--- a/src/data/courses.ts
+++ b/src/data/courses.ts
@@ -1,23 +1,65 @@
+export type StateInfo = {
+  codeSection: string;
+  guidance: string;
+};
+
 export type Course = {
   id: string;
   title: string;
   description: string;
+  trade: "plumbing" | "hvac" | "electrical";
+  states: Record<string, StateInfo>;
 };
 
 export const courses: Course[] = [
   {
-    id: 'intro-math',
-    title: 'Intro to Mathematics',
-    description: 'Learn basic math operations with interactive problems.',
+    id: "plumbing-prv",
+    title: "Installing Pressure Reducing Valves (PRV)",
+    description:
+      "Best practices for PRV installation in residential plumbing systems.",
+    trade: "plumbing",
+    states: {
+      CA: {
+        codeSection: "CA Plumbing Code §608.2",
+        guidance: "PRV required when supply pressure exceeds 80 psi.",
+      },
+      TX: {
+        codeSection: "IPC 2018 §604.8",
+        guidance: "Install downstream of meter; follow local amendments.",
+      },
+    },
   },
   {
-    id: 'physics-basics',
-    title: 'Physics Basics',
-    description: 'Explore fundamental physics concepts like motion and energy.',
+    id: "hvac-maintenance",
+    title: "HVAC Seasonal Maintenance",
+    description: "Interactive walkthrough for spring and fall tune-ups.",
+    trade: "hvac",
+    states: {
+      CA: {
+        codeSection: "CEC Title 24 Part 6",
+        guidance:
+          "Verify refrigerant charge and airflow per California requirements.",
+      },
+      NY: {
+        codeSection: "NYC Mechanical Code §403",
+        guidance: "Ventilation rates must meet table 403.3.1.1.",
+      },
+    },
   },
   {
-    id: 'cs-fundamentals',
-    title: 'Computer Science Fundamentals',
-    description: 'Understand algorithms and data structures through puzzles.',
+    id: "electrical-panel",
+    title: "Residential Service Panel Upgrades",
+    description: "Step-by-step NEC-compliant panel upgrades.",
+    trade: "electrical",
+    states: {
+      FL: {
+        codeSection: "NEC 2020 §408",
+        guidance: "Label circuits per Florida Building Code.",
+      },
+      WA: {
+        codeSection: "WAC 296-46B-408",
+        guidance: "AFCI protection required for bedroom circuits.",
+      },
+    },
   },
 ];

--- a/src/pages/api/courses/[id].ts
+++ b/src/pages/api/courses/[id].ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { courses } from '@/data/courses';
+import { courses, Course } from '@/data/courses';
 
 export default function handler(
   req: NextApiRequest,
-  res: NextApiResponse,
+  res: NextApiResponse<Course | { message: string }>,
 ) {
   const { id } = req.query;
   const course = courses.find((c) => c.id === id);

--- a/src/pages/api/courses/index.ts
+++ b/src/pages/api/courses/index.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { courses } from '@/data/courses';
+import { courses, Course } from '@/data/courses';
 
 export default function handler(
   _req: NextApiRequest,
-  res: NextApiResponse,
+  res: NextApiResponse<Course[]>,
 ) {
   res.status(200).json(courses);
 }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,24 @@
+import { extendTheme, ThemeConfig } from '@chakra-ui/react';
+
+const config: ThemeConfig = {
+  initialColorMode: 'dark',
+  useSystemColorMode: false,
+};
+
+const theme = extendTheme({
+  config,
+  styles: {
+    global: {
+      body: {
+        bg: '#000',
+        color: 'white',
+      },
+    },
+  },
+  fonts: {
+    heading: 'Inter, sans-serif',
+    body: 'Inter, sans-serif',
+  },
+});
+
+export default theme;


### PR DESCRIPTION
## Summary
- Switch site to a Vercel-inspired dark theme and navigation
- Provide plumbing, HVAC, and electrical courses with state-specific code references
- Add interactive course pages that surface code guidance based on selected state

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890d72f1278832688a4ab98579e7c75