### PR TITLE
Expand trade course catalog with pricing and chapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,25 @@ Join us today and start your journey to becoming a skilled contractor. With affo
 
 We want a website similar to Khan Academy where we would be an online learning platform that offers video lessons, interactive quizzes and exercises, and educational games. The website should have a clean and simple user interface with a navigation menu that is easy to use. The courses should be well-structured and organized into categories, making it easy for students to find the subjects they want to learn. The website should also have a tracking system to allow students to monitor their progress and receive feedback on their performance. Additionally, the website should have an easy-to-use discussion forum where students can engage with other students and instructors, ask questions, and receive support.
 
+# Course Offerings
+
+Our curriculum focuses on three core trades—plumbing, HVAC, and electrical. Each trade features a beginner guide, a continuing education track, and an advanced master course. Every course lists pricing and detailed descriptions, so students know exactly what they are purchasing before they enroll.
+
+- **Plumbing**
+  - *Beginner Guide*: foundational skills and tool overviews ($49)
+  - *Continuing Education*: code updates and safety refreshers ($99)
+  - *Master Course*: complex systems and leadership training ($199)
+- **HVAC**
+  - *Beginner Guide*: introduction to HVAC systems and safety ($49)
+  - *Continuing Education*: efficiency standards and troubleshooting ($99)
+  - *Master Course*: system design and project leadership ($199)
+- **Electrical**
+  - *Beginner Guide*: electrical theory and safety fundamentals ($49)
+  - *Continuing Education*: code revisions and smart technologies ($99)
+  - *Master Course*: industrial systems and management ($199)
+
+Selecting a course reveals full details, pricing, and chapter breakdowns. Interactive videos, charts, and quizzes guide learners through each chapter, and correct answers are required to progress.
+
 # Structure
 
 ## High School Students:

--- a/src/app/courses/[id]/page.tsx
+++ b/src/app/courses/[id]/page.tsx
@@ -1,11 +1,6 @@
 import NextLink from 'next/link';
-import { Box, Heading, Text, Link as ChakraLink } from '@chakra-ui/react';
-
-export type Course = {
-  id: string;
-  title: string;
-  description: string;
-};
+import { Box, Heading, Text, Link as ChakraLink, VStack } from '@chakra-ui/react';
+import type { Course } from '@/data/courses';
 
 async function getCourse(id: string): Promise<Course> {
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000';
@@ -25,7 +20,21 @@ export default async function CoursePage({
   return (
     <Box p={8} maxW="3xl" mx="auto">
       <Heading mb={4}>{course.title}</Heading>
-      <Text mb={6}>{course.description}</Text>
+      <Text fontWeight="bold" mb={2}>
+        Cost: ${course.price.toFixed(2)}
+      </Text>
+      <Text mb={6}>{course.details}</Text>
+      <Heading size="md" mb={4}>
+        Chapters
+      </Heading>
+      <VStack spacing={4} align="stretch" mb={6}>
+        {course.chapters.map((ch, idx) => (
+          <Box key={idx} p={4} borderWidth="1px" rounded="md">
+            <Text fontWeight="bold">{ch.title}</Text>
+            <Text>{ch.description}</Text>
+          </Box>
+        ))}
+      </VStack>
       <ChakraLink as={NextLink} href="/courses" color="blue.500">
         Back to courses
       </ChakraLink>

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -6,12 +6,7 @@ import {
   VStack,
   Link as ChakraLink,
 } from '@chakra-ui/react';
-
-export type Course = {
-  id: string;
-  title: string;
-  description: string;
-};
+import type { Course } from '@/data/courses';
 
 async function getCourses(): Promise<Course[]> {
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000';
@@ -38,6 +33,9 @@ export default async function CoursesPage() {
               {course.title}
             </ChakraLink>
             <Text>{course.description}</Text>
+            <Text fontWeight="bold" mt={2}>
+              ${course.price.toFixed(2)}
+            </Text>
           </Box>
         ))}
       </VStack>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,9 +2,9 @@ import { Box, Heading, Progress, Text, VStack } from '@chakra-ui/react';
 import { courses } from '@/data/courses';
 
 const userProgress: Record<string, number> = {
-  'osha-safety': 40,
-  'electrical-code': 20,
-  'plumbing-basics': 0,
+  'plumbing-beginner': 30,
+  'hvac-ce': 10,
+  'electrical-master': 0,
 };
 
 export default function DashboardPage() {

--- a/src/data/courses.ts
+++ b/src/data/courses.ts
@@ -1,25 +1,178 @@
-export type Course = {
-  id: string;
+export type Chapter = {
   title: string;
   description: string;
 };
 
+export type Course = {
+  id: string;
+  title: string;
+  description: string;
+  price: number;
+  details: string;
+  chapters: Chapter[];
+};
+
 export const courses: Course[] = [
   {
-    id: 'osha-safety',
-    title: 'OSHA Safety Training',
-    description: 'Comply with OSHA regulations and keep your job sites safe.',
+    id: 'plumbing-beginner',
+    title: 'Plumbing Beginner Guide',
+    description: 'Get started with basic plumbing skills.',
+    price: 49,
+    details:
+      'Introductory course covering fundamental plumbing concepts with interactive diagrams and videos.',
+    chapters: [
+      {
+        title: 'Tools Overview',
+        description: 'Learn about essential plumbing tools and safety gear.',
+      },
+      {
+        title: 'Pipe Installation Basics',
+        description: 'Understand pipe materials and basic installation techniques.',
+      },
+    ],
   },
   {
-    id: 'electrical-code',
-    title: 'Electrical Code Update',
-    description:
-      'Understand the latest National Electrical Code requirements for contractors.',
+    id: 'plumbing-ce',
+    title: 'Plumbing Continuing Education',
+    description: 'Stay current with plumbing codes and best practices.',
+    price: 99,
+    details:
+      'Updates and advanced topics to keep licensed plumbers up to date. Interactive videos and charts help reinforce learning.',
+    chapters: [
+      {
+        title: 'Code Updates',
+        description: 'Review the latest plumbing code changes.',
+      },
+      {
+        title: 'Safety Practices',
+        description: 'Advanced safety procedures and compliance.',
+      },
+    ],
   },
   {
-    id: 'plumbing-basics',
-    title: 'Residential Plumbing Basics',
-    description:
-      'Review common plumbing systems and installation best practices.',
+    id: 'plumbing-master',
+    title: 'Plumbing Master Course',
+    description: 'Advanced training for master plumbers.',
+    price: 199,
+    details:
+      'Deep dive into complex systems, leadership, and advanced code compliance. Includes interactive case studies.',
+    chapters: [
+      {
+        title: 'Commercial Systems',
+        description: 'Design and maintain large-scale plumbing installations.',
+      },
+      {
+        title: 'Green Plumbing Technology',
+        description: 'Explore sustainable and energy-efficient plumbing solutions.',
+      },
+    ],
+  },
+  {
+    id: 'hvac-beginner',
+    title: 'HVAC Beginner Guide',
+    description: 'Learn the basics of heating, ventilation, and air conditioning.',
+    price: 49,
+    details:
+      'Foundational HVAC concepts with interactive schematics and videos to build core skills.',
+    chapters: [
+      {
+        title: 'HVAC Tools and Safety',
+        description: 'Introduction to HVAC tools and safe operation.',
+      },
+      {
+        title: 'System Fundamentals',
+        description: 'Overview of heating and cooling system components.',
+      },
+    ],
+  },
+  {
+    id: 'hvac-ce',
+    title: 'HVAC Continuing Education',
+    description: 'Update your HVAC knowledge and maintain certification.',
+    price: 99,
+    details:
+      'Covers code updates, efficiency standards, and troubleshooting techniques using interactive content.',
+    chapters: [
+      {
+        title: 'Energy Efficiency Standards',
+        description: 'Study new efficiency requirements and best practices.',
+      },
+      {
+        title: 'Advanced Troubleshooting',
+        description: 'Interactive scenarios to diagnose complex HVAC issues.',
+      },
+    ],
+  },
+  {
+    id: 'hvac-master',
+    title: 'HVAC Master Course',
+    description: 'Master-level training for experienced HVAC technicians.',
+    price: 199,
+    details:
+      'Comprehensive coverage of system design, project management, and cutting-edge technology with interactive simulations.',
+    chapters: [
+      {
+        title: 'System Design',
+        description: 'Plan and design large-scale HVAC systems.',
+      },
+      {
+        title: 'Project Leadership',
+        description: 'Manage teams and complex installations effectively.',
+      },
+    ],
+  },
+  {
+    id: 'electrical-beginner',
+    title: 'Electrical Beginner Guide',
+    description: 'Understand basic electrical theory and practice.',
+    price: 49,
+    details:
+      'Starter course covering essential electrical concepts with interactive circuit diagrams and videos.',
+    chapters: [
+      {
+        title: 'Electrical Safety',
+        description: 'Fundamental safety procedures and personal protective equipment.',
+      },
+      {
+        title: 'Circuit Basics',
+        description: 'Learn about circuits, current, and voltage.',
+      },
+    ],
+  },
+  {
+    id: 'electrical-ce',
+    title: 'Electrical Continuing Education',
+    description: 'Keep up with electrical codes and emerging technologies.',
+    price: 99,
+    details:
+      'Explores recent code revisions, smart systems, and interactive problem-solving exercises.',
+    chapters: [
+      {
+        title: 'Code Revisions',
+        description: 'Detailed look at the latest National Electrical Code updates.',
+      },
+      {
+        title: 'Smart Technologies',
+        description: 'Integrating smart devices and controls safely.',
+      },
+    ],
+  },
+  {
+    id: 'electrical-master',
+    title: 'Electrical Master Course',
+    description: 'Expert-level course for seasoned electricians.',
+    price: 199,
+    details:
+      'Advanced topics including industrial systems, leadership, and interactive design projects.',
+    chapters: [
+      {
+        title: 'Industrial Systems',
+        description: 'Design and maintain complex industrial electrical networks.',
+      },
+      {
+        title: 'Leadership and Management',
+        description: 'Lead teams and manage large electrical projects.',
+      },
+    ],
   },
 ];


### PR DESCRIPTION
## Summary
- add beginner, continuing education, and master courses for plumbing, HVAC, and electrical trades
- show course pricing and chapter details on listing and detail pages
- track progress for new courses on the dashboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890ea51710083268ef1b4df519a377f