### PR TITLE
Fix Chakra UI components for app directory pages

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { Box, Heading, Text } from '@chakra-ui/react';
 
 export default function AboutPage() {

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { Box, Heading, Text, Link } from '@chakra-ui/react';
 
 export default function ContactPage() {

--- a/src/app/courses/CourseDetails.tsx
+++ b/src/app/courses/CourseDetails.tsx
@@ -1,0 +1,30 @@
+'use client';
+import NextLink from 'next/link';
+import { Box, Heading, Text, Link as ChakraLink, VStack } from '@chakra-ui/react';
+import type { Course } from '@/data/courses';
+
+export default function CourseDetails({ course }: { course: Course }) {
+  return (
+    <Box p={8} maxW="3xl" mx="auto">
+      <Heading mb={4}>{course.title}</Heading>
+      <Text fontWeight="bold" mb={2}>
+        Cost: ${course.price.toFixed(2)}
+      </Text>
+      <Text mb={6}>{course.details}</Text>
+      <Heading size="md" mb={4}>
+        Chapters
+      </Heading>
+      <VStack spacing={4} align="stretch" mb={6}>
+        {course.chapters.map((ch, idx) => (
+          <Box key={idx} p={4} borderWidth="1px" rounded="md">
+            <Text fontWeight="bold">{ch.title}</Text>
+            <Text>{ch.description}</Text>
+          </Box>
+        ))}
+      </VStack>
+      <ChakraLink as={NextLink} href="/courses" color="blue.500">
+        Back to courses
+      </ChakraLink>
+    </Box>
+  );
+}

--- a/src/app/courses/CoursesList.tsx
+++ b/src/app/courses/CoursesList.tsx
@@ -1,0 +1,25 @@
+'use client';
+import NextLink from 'next/link';
+import { Box, Heading, Text, VStack, Link as ChakraLink } from '@chakra-ui/react';
+import type { Course } from '@/data/courses';
+
+export default function CoursesList({ courses }: { courses: Course[] }) {
+  return (
+    <Box p={8} maxW="4xl" mx="auto">
+      <Heading mb={6}>Courses</Heading>
+      <VStack spacing={6} align="stretch">
+        {courses.map((course) => (
+          <Box key={course.id} p={4} borderWidth="1px" rounded="md">
+            <ChakraLink as={NextLink} href={`/courses/${course.id}`} fontWeight="bold">
+              {course.title}
+            </ChakraLink>
+            <Text>{course.description}</Text>
+            <Text fontWeight="bold" mt={2}>
+              ${course.price.toFixed(2)}
+            </Text>
+          </Box>
+        ))}
+      </VStack>
+    </Box>
+  );
+}

--- a/src/app/courses/[id]/page.tsx
+++ b/src/app/courses/[id]/page.tsx
@@ -1,6 +1,5 @@
-import NextLink from 'next/link';
-import { Box, Heading, Text, Link as ChakraLink, VStack } from '@chakra-ui/react';
 import type { Course } from '@/data/courses';
+import CourseDetails from '../CourseDetails';
 
 async function getCourse(id: string): Promise<Course> {
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000';
@@ -17,27 +16,5 @@ export default async function CoursePage({
   params: { id: string };
 }) {
   const course = await getCourse(params.id);
-  return (
-    <Box p={8} maxW="3xl" mx="auto">
-      <Heading mb={4}>{course.title}</Heading>
-      <Text fontWeight="bold" mb={2}>
-        Cost: ${course.price.toFixed(2)}
-      </Text>
-      <Text mb={6}>{course.details}</Text>
-      <Heading size="md" mb={4}>
-        Chapters
-      </Heading>
-      <VStack spacing={4} align="stretch" mb={6}>
-        {course.chapters.map((ch, idx) => (
-          <Box key={idx} p={4} borderWidth="1px" rounded="md">
-            <Text fontWeight="bold">{ch.title}</Text>
-            <Text>{ch.description}</Text>
-          </Box>
-        ))}
-      </VStack>
-      <ChakraLink as={NextLink} href="/courses" color="blue.500">
-        Back to courses
-      </ChakraLink>
-    </Box>
-  );
+  return <CourseDetails course={course} />;
 }

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -1,12 +1,5 @@
-import NextLink from 'next/link';
-import {
-  Box,
-  Heading,
-  Text,
-  VStack,
-  Link as ChakraLink,
-} from '@chakra-ui/react';
 import type { Course } from '@/data/courses';
+import CoursesList from './CoursesList';
 
 async function getCourses(): Promise<Course[]> {
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000';
@@ -19,26 +12,5 @@ async function getCourses(): Promise<Course[]> {
 
 export default async function CoursesPage() {
   const courses = await getCourses();
-  return (
-    <Box p={8} maxW="4xl" mx="auto">
-      <Heading mb={6}>Courses</Heading>
-      <VStack spacing={6} align="stretch">
-        {courses.map((course) => (
-          <Box key={course.id} p={4} borderWidth="1px" rounded="md">
-            <ChakraLink
-              as={NextLink}
-              href={`/courses/${course.id}`}
-              fontWeight="bold"
-            >
-              {course.title}
-            </ChakraLink>
-            <Text>{course.description}</Text>
-            <Text fontWeight="bold" mt={2}>
-              ${course.price.toFixed(2)}
-            </Text>
-          </Box>
-        ))}
-      </VStack>
-    </Box>
-  );
+  return <CoursesList courses={courses} />;
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { Box, Heading, Progress, Text, VStack } from '@chakra-ui/react';
 import { courses } from '@/data/courses';
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+"use client";
 import NextLink from 'next/link';
 import { Box, Button, Heading, Text, Stack } from '@chakra-ui/react';
 


### PR DESCRIPTION
## Summary
- Mark home, about, contact, and dashboard pages as client components so Chakra UI works in the app directory
- Refactor course routes to fetch data on the server and render through new client components

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890ee89b7b483268b3dabfc442770e6